### PR TITLE
add line to load Hamburger.js (it was missing)

### DIFF
--- a/_includes/Nav.html
+++ b/_includes/Nav.html
@@ -33,7 +33,8 @@
     <div class="navbar-brand">
       <a class="navbar-item" style="padding-left: 0;"; href="{{ site.baseurl }}/index.html">
           <h6> {{site.heading}}</h6></a>
-          <script src="{{ site.baseurl }}/assets/js/modeswitcher.js"></script>  
+          <script src="{{ site.baseurl }}/assets/js/modeswitcher.js"></script>
+          <script src="{{ site.baseurl }}/assets/js/Hamburger.js"></script>
       <div class="navbar-item navbar-dark-mode__mobile is-hidden-tablet" onclick="modeSwitcher()">
         <div class="buttons">
           <a class="button is-text">


### PR DESCRIPTION
There's no line that load Hamburger.js to allow the hamburger menu to apply `.is-active` class and allow the block to expand. I add the line to what I think is natural i.e. `_includes\Nav.html`. I tested it on my digital garden and seems to work.