### PR TITLE
Replace invalid reference to FeedContent.html with Content.html

### DIFF
--- a/_layouts/Post.html
+++ b/_layouts/Post.html
@@ -84,7 +84,7 @@
                 <div class="column is-6-widescreen  is-8-desktop is-8-tablet is-12-mobile">
                             <h5 class="meta-title"><a href="/">← Home</a></h5>
                             <div class="jumbo">{{page.title}}</div>
-                            {%- include FeedContent.html -%}
+                            {%- include Content.html -%}
                             {%- include Feed.html -%}
                 </div>
                     {%- endif -%}


### PR DESCRIPTION
Posts.html refers attempts to include FeedContent.html, however that file doesn't exist. This commit changes it to include Content.html instead.